### PR TITLE
[Hotfix] Stop signing out user on wallet reconnection failure.

### DIFF
--- a/packages/ui/src/context/WalletConnection/index.tsx
+++ b/packages/ui/src/context/WalletConnection/index.tsx
@@ -139,12 +139,12 @@ export const WalletConnectionProvider = ({  protocol = 'shannon', children, expe
     setAllConnectedIdentities(pocketConnection.connectedIdentities ?? []);
 
     if (!reconnected) {
-      if (onDisconnect) {
-        onDisconnect();
-        return false;
-      } else {
-        throw new Error('Failed to reconnect');
-      }
+    //   if (onDisconnect) {
+    //     onDisconnect();
+    //     return false;
+    //   } else {
+      throw new Error('Failed to reconnect');
+      // }
     }
 
     return true;


### PR DESCRIPTION
We will see what's going on and make a fix to this problem.