### PR TITLE
fix(middleman): resolve broadcast failures through the verifier

### DIFF
--- a/apps/middleman-workflows/src/activities/index.ts
+++ b/apps/middleman-workflows/src/activities/index.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationFailure,
+  Context,
   heartbeat,
   log,
   sleep,
@@ -24,6 +25,7 @@ import { extractTransactionStakingSuppliers, extractTransactionUnstakingSupplier
 import { ProviderService } from '@/lib/provider'
 import DAL from '@/lib/dal/DAL'
 import type { PocketBlockchain, SupplierServiceConfig, SupplierEndpoint, ServiceRevenueShare, VerifyOutcome, SupplierEffect } from '@igniter/pocket'
+import { deriveTxHash } from '@igniter/pocket'
 import type { VerificationDecision, SupplierPathOutcome } from '@igniter/tx-verify'
 import { TX_EXPIRATION_BLOCKS } from '@igniter/tx-verify'
 import { STAKE_TYPE_URL, UNSTAKE_TYPE_URL } from '@/lib/constants'
@@ -490,11 +492,66 @@ export const delegatorActivities = (dal: DAL, pocketRpcClient: PocketBlockchain,
     return await dal.transaction.updateTransaction(transactionId, payload)
   },
   /**
-   * Executes a transaction based on the given transaction ID.
+   * Writes the broadcast anchor BEFORE any bytes are sent: the locally derived hash, the height
+   * sampled pre-broadcast, and the timeoutHeight embedded at signing. Returns the hash, or null
+   * when the signed payload cannot be decoded at all (deterministic, and terminal).
    *
-   * @param {number} transactionId - The unique identifier of the transaction to be executed.
-   * @return {Promise<any>} A promise that resolves with the result of the transaction execution or rejects if the transaction is not found or not signed.
+   * Ordering is the point. If the hash were written after broadcasting, any failure in between
+   * (worker crash, activity timeout) would re-enter the workflow with `hash === null` and
+   * broadcast the same bytes a second time. Mirrors the provider's `signSupplierTx`, which
+   * persists hash + expiry before `broadcastSupplierTx` runs.
    */
+  async persistBroadcastAnchor(transactionId: number, executionHeight: number): Promise<string | null> {
+    const transaction = await dal.transaction.getTransaction(transactionId)
+    if (!transaction) {
+      throw new Error('Transaction not found')
+    }
+    if (!transaction.signedPayload) {
+      throw new Error('Transaction is not signed')
+    }
+
+    let hash: string
+    try {
+      hash = deriveTxHash(transaction.signedPayload)
+    } catch (error) {
+      // An unhashable payload is deterministic proof the tx can never be broadcast, let alone
+      // land. Returning null (rather than throwing) hands the workflow a terminal verdict —
+      // throwing would retry the activity, fail the workflow, and let the 10s dispatcher relaunch
+      // it forever on a row that can never succeed.
+      log.error('broadcast anchor: signed payload is not hashable', { transactionId, error })
+      return null
+    }
+
+    const { timeoutHeight } = parseSignerAndSequence(transaction.signedPayload)
+
+    await dal.transaction.updateTransaction(transactionId, { hash, executionHeight, timeoutHeight })
+    log.info('broadcast anchor persisted', { transactionId, hash, executionHeight, timeoutHeight })
+
+    return hash
+  },
+  /**
+   * Diagnostics-only write (code/log), applied only while the row is still pending.
+   *
+   * Best-effort triage: the verifier's terminal write sets `log` unconditionally, so this text
+   * survives only until a verdict is reached. It is here so an operator inspecting a row that is
+   * still in flight can see WHY it is waiting.
+   */
+  async recordBroadcastDiagnostics(transactionId: number, fields: { code?: number; log?: string }): Promise<void> {
+    await dal.transaction.recordPendingDiagnostics(transactionId, fields)
+  },
+  /**
+   * Terminal transition guarded by the same CAS the verifier uses: it only wins while the row is
+   * still `pending`. Without it the broadcaster's late retry could overwrite a verdict the
+   * verifier already reached — the row is visible to the sweep from the moment it is anchored.
+   * Returns true iff THIS call performed the transition.
+   */
+  async claimBroadcastFailure(transactionId: number, fields: { code?: number; log?: string }): Promise<boolean> {
+    const row = await dal.transaction.claimTerminalTransition(transactionId, TransactionStatus.Failure, fields)
+    if (!row) {
+      log.info('broadcast failure CAS lost — transaction already terminal', { transactionId })
+    }
+    return Boolean(row)
+  },
   async executeTransaction(transactionId: number) {
     const transaction = await dal.transaction.getTransaction(transactionId)
     if (!transaction) {
@@ -505,20 +562,50 @@ export const delegatorActivities = (dal: DAL, pocketRpcClient: PocketBlockchain,
       throw new Error('Transaction is not signed')
     }
 
+    // Which attempt this is decides whether a CheckTx rejection can be trusted. On attempt 1 no
+    // bytes have gone out before, so a rejection is about THIS tx. On a retry the previous attempt
+    // may already have put the tx on chain, and the node is then answering about the world that tx
+    // created — an insufficient-funds or sequence error that says "it already landed", not "it
+    // failed". Only the verifier can tell those apart, so retries never terminalize.
+    let attempt = 1
+    try {
+      attempt = Context.current().info.attempt
+    } catch {
+      // Not running inside an activity context (unit tests) — treat as the first attempt.
+    }
+
     const result = await pocketRpcClient.sendTransaction(transaction.signedPayload)
 
-    if (result.transactionHash) {
+    // The hash is derived locally by sendTransaction, so it is present on every outcome.
+    // What separates the three cases is success/rejected — log them apart so an operator can
+    // tell "the node refused this" from "we never heard back" in the logs.
+    if (result.success) {
       log.info('transaction broadcast', { transactionId, hash: result.transactionHash, type: transaction.type })
-    } else {
-      log.warn('transaction broadcast failed', {
+    } else if (result.rejected) {
+      log.warn('transaction broadcast rejected', {
         transactionId,
         type: transaction.type,
+        hash: result.transactionHash,
         code: result.code,
+        message: result.message,
+      })
+    } else if (result.neverSent) {
+      log.warn('transaction not broadcast (RPC unreachable)', {
+        transactionId,
+        type: transaction.type,
+        message: result.message,
+      })
+    } else {
+      log.warn('transaction broadcast outcome unknown (may still land)', {
+        transactionId,
+        type: transaction.type,
+        hash: result.transactionHash,
+        isTimeout: result.isTimeout,
         message: result.message,
       })
     }
 
-    return result
+    return { ...result, attempt }
   },
   /**
    * Retrieves the current block height from the RPC client.

--- a/apps/middleman-workflows/src/activities/parseSignerAndSequence.test.ts
+++ b/apps/middleman-workflows/src/activities/parseSignerAndSequence.test.ts
@@ -1,0 +1,50 @@
+import { TxRaw, TxBody, AuthInfo } from '@igniter/pocket/proto/cosmos/tx/v1beta1/tx'
+import { parseSignerAndSequence } from './parseSignerAndSequence'
+
+/**
+ * Regression guard for #339's blocker: this decoded base64 while middleman stores hex, so it
+ * returned nulls for every transaction. That starved `decideVerification` of the timeoutHeight
+ * and sequence evidence it needs to declare a tx absent, leaving failed transactions pending
+ * forever. Hex digits are valid base64 characters, so the bug never threw where anyone could
+ * see it — hence this file, which the function shipped two releases without.
+ */
+function buildSignedPayloadHex({ sequence, timeoutHeight }: { sequence: number; timeoutHeight: number }): string {
+  const bodyBytes = TxBody.encode(TxBody.fromPartial({ messages: [], timeoutHeight })).finish()
+  const authInfoBytes = AuthInfo.encode(AuthInfo.fromPartial({
+    signerInfos: [{ sequence }],
+  })).finish()
+  const txRawBytes = TxRaw.encode(TxRaw.fromPartial({
+    bodyBytes,
+    authInfoBytes,
+    signatures: [new Uint8Array([1, 2, 3])],
+  })).finish()
+  return Buffer.from(txRawBytes).toString('hex')
+}
+
+describe('parseSignerAndSequence', () => {
+  it('reads sequence and timeoutHeight from a hex payload (the encoding middleman stores)', () => {
+    const payload = buildSignedPayloadHex({ sequence: 7, timeoutHeight: 1030 })
+
+    expect(parseSignerAndSequence(payload)).toEqual({ sequence: 7, timeoutHeight: 1030 })
+  })
+
+  it('returns a sequence with timeoutHeight null when the wallet embedded no timeout', () => {
+    const payload = buildSignedPayloadHex({ sequence: 12, timeoutHeight: 0 })
+
+    expect(parseSignerAndSequence(payload)).toEqual({ sequence: 12, timeoutHeight: null })
+  })
+
+  it('does NOT parse a base64 payload — the pre-#339 encoding this regressed on', () => {
+    const hex = buildSignedPayloadHex({ sequence: 7, timeoutHeight: 1030 })
+    const base64 = Buffer.from(hex, 'hex').toString('base64')
+
+    // Proves the two encodings are not interchangeable: whichever one the function decodes,
+    // the other yields no evidence. Middleman is hex, so hex is the one that must work.
+    expect(parseSignerAndSequence(base64)).toEqual({ sequence: null, timeoutHeight: null })
+  })
+
+  it('returns nulls on garbage instead of throwing', () => {
+    expect(parseSignerAndSequence('not-a-payload')).toEqual({ sequence: null, timeoutHeight: null })
+    expect(parseSignerAndSequence('')).toEqual({ sequence: null, timeoutHeight: null })
+  })
+})

--- a/apps/middleman-workflows/src/activities/parseSignerAndSequence.ts
+++ b/apps/middleman-workflows/src/activities/parseSignerAndSequence.ts
@@ -1,7 +1,19 @@
 import { TxRaw, AuthInfo, TxBody } from '@igniter/pocket/proto/cosmos/tx/v1beta1/tx'
 
 /**
- * Parses signer sequence and timeoutHeight from a base64-encoded signed TxRaw payload.
+ * Parses signer sequence and timeoutHeight from a HEX-encoded signed TxRaw payload.
+ *
+ * Encoding matters and is app-specific: middleman payloads are hex — both wallets store them
+ * that way (KeplrWalletConnection `toString("hex")`, PocketWalletConnection `transactionHex`)
+ * and the broadcaster decodes them with `Buffer.from(payload, 'hex')`. Provider payloads are
+ * base64; this function is middleman-only and must not be pointed at provider data.
+ *
+ * This decoded base64 until #339. Because hex digits are also valid base64 characters, the
+ * mistake never threw at the decode step — it produced garbage bytes, TxRaw.decode failed, and
+ * the catch below returned nulls for EVERY transaction. That silently removed the only evidence
+ * `decideVerification` can use to declare a tx absent, so no middleman transaction could ever
+ * reach a failure verdict; they stayed pending forever.
+ *
  * Returns null values on parse failure (activity caller treats as no evidence → pending).
  */
 export function parseSignerAndSequence(signedPayload: string): {
@@ -9,7 +21,7 @@ export function parseSignerAndSequence(signedPayload: string): {
   timeoutHeight: number | null
 } {
   try {
-    const txBytes = Buffer.from(signedPayload, 'base64')
+    const txBytes = Buffer.from(signedPayload, 'hex')
     const txRaw = TxRaw.decode(txBytes)
     const authInfo = AuthInfo.decode(txRaw.authInfoBytes)
     const sequence = authInfo.signerInfos[0]?.sequence ?? null

--- a/apps/middleman-workflows/src/lib/dal/transaction.ts
+++ b/apps/middleman-workflows/src/lib/dal/transaction.ts
@@ -81,6 +81,25 @@ export default class Transaction {
   }
 
   /**
+   * Diagnostics-only write (code/log) that applies ONLY while the row is still pending.
+   * The status predicate is the point: an anchored row is visible to the verifier from the
+   * moment it is written, so an unguarded update from the broadcaster could overwrite the
+   * code/log of a verdict the verifier already reached.
+   */
+  async recordPendingDiagnostics(
+    transactionId: number,
+    fields: { code?: number; log?: string },
+  ): Promise<void> {
+    await this.dbClient.db
+      .update(transactionsTable)
+      .set(fields)
+      .where(and(
+        eq(transactionsTable.id, transactionId),
+        eq(transactionsTable.status, TransactionStatus.Pending),
+      ));
+  }
+
+  /**
    * Pending-path counter/coverage update (no status change). Drizzle skips
    * `undefined` set fields, so passing `undefined` leaves a column untouched.
    */

--- a/apps/middleman-workflows/src/workflows/ExecuteTransaction.test.ts
+++ b/apps/middleman-workflows/src/workflows/ExecuteTransaction.test.ts
@@ -1,0 +1,304 @@
+// ---------------------------------------------------------------------------
+// Mocks – must be declared before importing the workflow under test
+// ---------------------------------------------------------------------------
+
+const activityMocks = {
+  getTransaction: jest.fn(),
+  updateTransaction: jest.fn(),
+  executeTransaction: jest.fn(),
+  persistBroadcastAnchor: jest.fn(),
+  // Only the legacy flow calls this; it stays until that branch is deleted.
+  getTxTimeoutHeight: jest.fn(),
+  claimBroadcastFailure: jest.fn(),
+  recordBroadcastDiagnostics: jest.fn(),
+  getBlockHeight: jest.fn(),
+  notifyProviderOfFailedStakes: jest.fn(),
+  notifyUserOfFailedTransaction: jest.fn(),
+}
+
+// There is no workflow test harness in this repo (@temporalio/testing is not a dependency —
+// see noWorkflowError.test.ts), so the workflow is exercised as a plain async function with
+// its activity proxy stubbed. That covers the branch logic, which is what #339 turns on; it
+// does NOT cover determinism/replay semantics, which only the real SDK runtime can check.
+// `patched()` decides which flow runs: true = post-#339 anchored flow (every new run),
+// false = the legacy flow kept for histories recorded before the upgrade.
+const mockPatched = jest.fn(() => true)
+
+jest.mock('@temporalio/workflow', () => ({
+  proxyActivities: () => activityMocks,
+  patched: (...args: unknown[]) => mockPatched(...(args as [])),
+  ApplicationFailure: class extends Error {},
+  log: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+import { ExecuteTransaction } from './ExecuteTransaction'
+import { TransactionStatus, TransactionType } from '@igniter/db/middleman/enums'
+
+const TX_ID = 42
+const LOCAL_HASH = 'ABCDEF01'.repeat(8)
+const BROADCAST_HEIGHT = 1000
+
+function pendingTx(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TX_ID,
+    status: TransactionStatus.Pending,
+    type: TransactionType.Stake,
+    hash: null,
+    executionHeight: null,
+    ...overrides,
+  }
+}
+
+/** Order in which two jest mocks were first invoked. */
+function calledBefore(first: jest.Mock, second: jest.Mock): boolean {
+  return first.mock.invocationCallOrder[0]! < second.mock.invocationCallOrder[0]!
+}
+
+/**
+ * #339: a broadcast that returns no clean answer is NOT proof of failure. Only a deterministic
+ * CheckTx rejection is. Everything else must stay `pending` WITH a hash so the verifier's queue
+ * (listPendingWithHash: pending + hash + executionHeight) can pick it up and settle it against
+ * the chain.
+ */
+describe('ExecuteTransaction — broadcast outcome handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPatched.mockReturnValue(true)
+    activityMocks.getTransaction.mockResolvedValue(pendingTx())
+    activityMocks.getBlockHeight.mockResolvedValue(BROADCAST_HEIGHT)
+    activityMocks.persistBroadcastAnchor.mockResolvedValue(LOCAL_HASH)
+    activityMocks.claimBroadcastFailure.mockResolvedValue(true)
+    activityMocks.recordBroadcastDiagnostics.mockResolvedValue(undefined)
+    activityMocks.updateTransaction.mockResolvedValue(undefined)
+    activityMocks.notifyProviderOfFailedStakes.mockResolvedValue(undefined)
+    activityMocks.notifyUserOfFailedTransaction.mockResolvedValue(undefined)
+  })
+
+  it('RPC unreachable: keeps the anchor and lets the verifier settle it', async () => {
+    activityMocks.executeTransaction.mockResolvedValue({
+      transactionHash: LOCAL_HASH, success: false, rejected: false, neverSent: true, attempt: 1, message: 'RPC unreachable',
+    })
+
+    const out = await ExecuteTransaction({ transactionId: TX_ID })
+
+    // The anchor must NOT be rolled back: clearing a hash for a tx that might be in a mempool
+    // would hide it from the verifier, which is #339 itself. Unknown outcome → verifier owns it.
+    expect(activityMocks.claimBroadcastFailure).not.toHaveBeenCalled()
+    expect(activityMocks.notifyUserOfFailedTransaction).not.toHaveBeenCalled()
+    expect(activityMocks.recordBroadcastDiagnostics).toHaveBeenCalledWith(TX_ID, expect.objectContaining({ log: 'RPC unreachable' }))
+    expect(out.hash).toBe(LOCAL_HASH)
+  })
+
+  it('rejection on a RETRY: does not terminalize — the earlier attempt may have landed the tx', async () => {
+    activityMocks.executeTransaction.mockResolvedValue({
+      transactionHash: LOCAL_HASH, success: false, rejected: true, attempt: 2, code: 5, message: 'insufficient funds',
+    })
+
+    await ExecuteTransaction({ transactionId: TX_ID })
+
+    expect(activityMocks.claimBroadcastFailure).not.toHaveBeenCalled()
+    expect(activityMocks.notifyProviderOfFailedStakes).not.toHaveBeenCalled()
+    expect(activityMocks.notifyUserOfFailedTransaction).not.toHaveBeenCalled()
+    // Falls through to the unknown-outcome path, which only records diagnostics.
+    expect(activityMocks.recordBroadcastDiagnostics).toHaveBeenCalledWith(TX_ID, expect.objectContaining({ code: 5 }))
+  })
+
+  it('unhashable payload: terminal Failure instead of an infinite dispatch loop', async () => {
+    activityMocks.persistBroadcastAnchor.mockResolvedValue(null)
+
+    const out = await ExecuteTransaction({ transactionId: TX_ID })
+
+    expect(activityMocks.executeTransaction).not.toHaveBeenCalled()
+    expect(activityMocks.notifyProviderOfFailedStakes).toHaveBeenCalledWith(TX_ID)
+    expect(activityMocks.updateTransaction).toHaveBeenCalledWith(TX_ID, expect.objectContaining({
+      status: TransactionStatus.Failure,
+    }))
+    expect(out.status).toBe(TransactionStatus.Failure)
+  })
+
+  it('terminal failure goes through the CAS, never a blind write', async () => {
+    activityMocks.executeTransaction.mockResolvedValue({
+      transactionHash: LOCAL_HASH, success: false, rejected: true, attempt: 1, code: 11, message: 'out of gas',
+    })
+
+    await ExecuteTransaction({ transactionId: TX_ID })
+
+    // updateTransaction would clobber a verdict the verifier may already have written.
+    expect(activityMocks.claimBroadcastFailure).toHaveBeenCalledWith(TX_ID, expect.objectContaining({ code: 11 }))
+    expect(activityMocks.updateTransaction).not.toHaveBeenCalled()
+  })
+
+  it('anchors hash + height BEFORE broadcasting, so a crash cannot re-broadcast', async () => {
+    activityMocks.executeTransaction.mockResolvedValue({ transactionHash: LOCAL_HASH, success: true, rejected: false })
+
+    await ExecuteTransaction({ transactionId: TX_ID })
+
+    expect(activityMocks.persistBroadcastAnchor).toHaveBeenCalledWith(TX_ID, BROADCAST_HEIGHT)
+    expect(calledBefore(activityMocks.persistBroadcastAnchor, activityMocks.executeTransaction)).toBe(true)
+  })
+
+  it('rejected on the first attempt: Failure via CAS, user notified, addresses released', async () => {
+    activityMocks.executeTransaction.mockResolvedValue({
+      transactionHash: LOCAL_HASH, success: false, rejected: true, attempt: 1, code: 11, message: 'out of gas',
+    })
+
+    const out = await ExecuteTransaction({ transactionId: TX_ID })
+
+    expect(activityMocks.claimBroadcastFailure).toHaveBeenCalledWith(TX_ID, expect.objectContaining({ code: 11 }))
+    expect(activityMocks.notifyUserOfFailedTransaction).toHaveBeenCalled()
+    expect(activityMocks.notifyProviderOfFailedStakes).toHaveBeenCalledWith(TX_ID)
+    expect(out.status).toBe(TransactionStatus.Failure)
+  })
+
+  it('rejected: claims the row BEFORE running any effect, since the verifier may disagree', async () => {
+    activityMocks.executeTransaction.mockResolvedValue({
+      transactionHash: LOCAL_HASH, success: false, rejected: true, attempt: 1, code: 11, message: 'out of gas',
+    })
+
+    await ExecuteTransaction({ transactionId: TX_ID })
+
+    expect(calledBefore(activityMocks.claimBroadcastFailure, activityMocks.notifyProviderOfFailedStakes)).toBe(true)
+    expect(calledBefore(activityMocks.claimBroadcastFailure, activityMocks.notifyUserOfFailedTransaction)).toBe(true)
+  })
+
+  it('CAS lost (verifier settled first): releases nothing and notifies nobody', async () => {
+    activityMocks.claimBroadcastFailure.mockResolvedValue(false)
+    activityMocks.executeTransaction.mockResolvedValue({
+      transactionHash: LOCAL_HASH, success: false, rejected: true, attempt: 1, code: 11, message: 'out of gas',
+    })
+
+    const out = await ExecuteTransaction({ transactionId: TX_ID })
+
+    // The verifier can settle this row Success on goal-state alone (a sibling tx staked the same
+    // operator). Releasing those addresses would contradict a verdict that stands, and telling
+    // the user it failed would contradict it twice.
+    expect(activityMocks.notifyProviderOfFailedStakes).not.toHaveBeenCalled()
+    expect(activityMocks.notifyUserOfFailedTransaction).not.toHaveBeenCalled()
+    expect(out.status).toBe(TransactionStatus.Pending)
+  })
+
+  it('rejected non-stake: does NOT call the stake-release hook', async () => {
+    activityMocks.getTransaction.mockResolvedValue(pendingTx({ type: TransactionType.Unstake }))
+    activityMocks.executeTransaction.mockResolvedValue({
+      transactionHash: LOCAL_HASH, success: false, rejected: true, attempt: 1, code: 11, message: 'out of gas',
+    })
+
+    await ExecuteTransaction({ transactionId: TX_ID })
+
+    expect(activityMocks.notifyProviderOfFailedStakes).not.toHaveBeenCalled()
+    expect(activityMocks.notifyUserOfFailedTransaction).toHaveBeenCalled()
+  })
+
+  it('timeout: stays pending, records the reason, notifies nobody', async () => {
+    activityMocks.executeTransaction.mockResolvedValue({
+      transactionHash: LOCAL_HASH, success: false, rejected: false, attempt: 1, isTimeout: true, message: 'RPC timeout',
+    })
+
+    const out = await ExecuteTransaction({ transactionId: TX_ID })
+
+    // Diagnostics only, through the pending-guarded write — never a status change.
+    expect(activityMocks.recordBroadcastDiagnostics).toHaveBeenCalledWith(TX_ID, expect.objectContaining({ log: 'RPC timeout' }))
+    expect(activityMocks.updateTransaction).not.toHaveBeenCalled()
+    expect(activityMocks.claimBroadcastFailure).not.toHaveBeenCalled()
+    expect(activityMocks.notifyUserOfFailedTransaction).not.toHaveBeenCalled()
+    expect(activityMocks.notifyProviderOfFailedStakes).not.toHaveBeenCalled()
+    expect(out.hash).toBe(LOCAL_HASH)
+  })
+
+  it('transport failure (no rejection flag): stays pending with the anchored hash', async () => {
+    activityMocks.executeTransaction.mockResolvedValue({
+      transactionHash: LOCAL_HASH, success: false, rejected: false, attempt: 1, message: 'socket hang up',
+    })
+
+    const out = await ExecuteTransaction({ transactionId: TX_ID })
+
+    expect(activityMocks.persistBroadcastAnchor).toHaveBeenCalledWith(TX_ID, BROADCAST_HEIGHT)
+    expect(activityMocks.notifyUserOfFailedTransaction).not.toHaveBeenCalled()
+    expect(out.hash).toBe(LOCAL_HASH)
+  })
+
+  it('undefined rejected (legacy shape) is treated as not-rejected', async () => {
+    activityMocks.executeTransaction.mockResolvedValue({
+      transactionHash: LOCAL_HASH, success: false, message: 'unknown error',
+    })
+
+    await ExecuteTransaction({ transactionId: TX_ID })
+
+    expect(activityMocks.claimBroadcastFailure).not.toHaveBeenCalled()
+    expect(activityMocks.updateTransaction).not.toHaveBeenCalled()
+    expect(activityMocks.notifyUserOfFailedTransaction).not.toHaveBeenCalled()
+  })
+
+  it('success: leaves the anchored row pending for the verifier, writes no status', async () => {
+    activityMocks.executeTransaction.mockResolvedValue({
+      transactionHash: LOCAL_HASH, success: true, rejected: false,
+    })
+
+    const out = await ExecuteTransaction({ transactionId: TX_ID })
+
+    expect(activityMocks.updateTransaction).not.toHaveBeenCalled()
+    expect(out.hash).toBe(LOCAL_HASH)
+    expect(out.executionHeight).toBe(BROADCAST_HEIGHT)
+  })
+
+  it('already broadcast (hash present): returns early without anchoring or broadcasting', async () => {
+    activityMocks.getTransaction.mockResolvedValue(pendingTx({ hash: LOCAL_HASH }))
+
+    await ExecuteTransaction({ transactionId: TX_ID })
+
+    expect(activityMocks.persistBroadcastAnchor).not.toHaveBeenCalled()
+    expect(activityMocks.executeTransaction).not.toHaveBeenCalled()
+    expect(activityMocks.updateTransaction).not.toHaveBeenCalled()
+  })
+
+  // Runs that were already open when the new version deployed replay this path. It must keep
+  // working — and, because activities are never version-pinned, it inherits the fixed
+  // sendTransaction and so no longer strands a transport failure.
+  describe('legacy flow (pre-#339 histories, patched() === false)', () => {
+    beforeEach(() => {
+      mockPatched.mockReturnValue(false)
+    })
+
+    it('does not anchor, and persists the hash after broadcasting', async () => {
+      activityMocks.getTxTimeoutHeight.mockResolvedValue(1030)
+      activityMocks.executeTransaction.mockResolvedValue({
+        transactionHash: LOCAL_HASH, success: true, rejected: false, attempt: 1,
+      })
+
+      const out = await ExecuteTransaction({ transactionId: TX_ID })
+
+      expect(activityMocks.persistBroadcastAnchor).not.toHaveBeenCalled()
+      expect(activityMocks.updateTransaction).toHaveBeenCalledWith(TX_ID, {
+        executionHeight: BROADCAST_HEIGHT,
+        hash: LOCAL_HASH,
+        timeoutHeight: 1030,
+      })
+      expect(out.hash).toBe(LOCAL_HASH)
+    })
+
+    it('inherits the fix: a transport failure now carries a hash, so it is not marked Failure', async () => {
+      activityMocks.getTxTimeoutHeight.mockResolvedValue(null)
+      activityMocks.executeTransaction.mockResolvedValue({
+        transactionHash: LOCAL_HASH, success: false, rejected: false, attempt: 1, message: 'socket hang up',
+      })
+
+      await ExecuteTransaction({ transactionId: TX_ID })
+
+      const written = activityMocks.updateTransaction.mock.calls.map((c) => c[1])
+      expect(written.every((payload) => !('status' in payload))).toBe(true)
+      expect(activityMocks.notifyUserOfFailedTransaction).not.toHaveBeenCalled()
+    })
+  })
+
+  it('expired before broadcast: effects run before the status flip, and nothing is broadcast', async () => {
+    activityMocks.getTransaction.mockResolvedValue(pendingTx({ executionHeight: 1 }))
+
+    await ExecuteTransaction({ transactionId: TX_ID })
+
+    expect(activityMocks.executeTransaction).not.toHaveBeenCalled()
+    expect(calledBefore(activityMocks.notifyProviderOfFailedStakes, activityMocks.updateTransaction)).toBe(true)
+    expect(activityMocks.updateTransaction).toHaveBeenCalledWith(TX_ID, expect.objectContaining({
+      status: TransactionStatus.Failure,
+    }))
+  })
+})

--- a/apps/middleman-workflows/src/workflows/ExecuteTransaction.ts
+++ b/apps/middleman-workflows/src/workflows/ExecuteTransaction.ts
@@ -1,7 +1,8 @@
 import {
-  log,
-  proxyActivities,
   ApplicationFailure,
+  log,
+  patched,
+  proxyActivities,
 } from '@temporalio/workflow'
 import { delegatorActivities } from "@/activities";
 import { TransactionStatus, TransactionType } from '@igniter/db/middleman/enums'
@@ -11,46 +12,260 @@ interface TransactionArgs {
   transactionId: number;
 }
 
+type Activities = ReturnType<typeof delegatorActivities>
+type ProxiedActivities = ReturnType<typeof proxyActivities<Activities>>
+type TransactionRow = Awaited<ReturnType<Activities['getTransaction']>>
+
 /**
- * Broadcaster. Signs + broadcasts a pending transaction, persists its hash and
- * execution height, then leaves it `pending` (now with a hash) for the
- * VerifyPendingTransactions sweeper to verify. No verification happens here —
- * that responsibility moved to the verifier so a slow/down RPC can never turn a
- * broadcast into a false failure on this path.
+ * Marks the second command sequence this workflow has emitted. The id names the Temporal-level
+ * fact — the order of activities recorded in a run's history changed — rather than the business
+ * change that motivated it (#339), because that is what a replaying worker is comparing against.
+ *
+ * The v1 sequence was:
+ *   getTransaction → getBlockHeight → executeTransaction → getTxTimeoutHeight → updateTransaction
+ * v2 is:
+ *   getTransaction → getBlockHeight → persistBroadcastAnchor → executeTransaction → …
+ * plus reordered terminal branches (effects before the status flip) and CAS-guarded writes.
+ *
+ * WHY THIS EXISTS. Temporal does not resume a workflow where it stopped — it replays the
+ * recorded history from the top and checks that the code emits the same commands in the same
+ * order. Igniter is upgraded by stopping and restarting the process, and workflow state lives in
+ * Temporal's own database, so any ExecuteTransaction open at that moment is replayed by the NEW
+ * code against a history written by the OLD code. This rework inserts `persistBroadcastAnchor`
+ * before the broadcast, drops `getTxTimeoutHeight`, and reorders the terminal branches — three
+ * divergences. Without this gate the replay mismatches, Temporal fails the workflow TASK (not the
+ * run) and retries it forever: the run sits in RUNNING permanently, the 10s dispatcher cannot
+ * start a replacement (`ALLOW_DUPLICATE_FAILED_ONLY` only allows one when the previous run
+ * FAILED), and the transaction is stranded — either never broadcast, or broadcast and on-chain
+ * while the row carries no hash for the verifier to find. Silent, and it needs a manual terminate
+ * in the Temporal UI to clear.
+ *
+ * `patched()` returns false when replaying a history recorded before this marker existed, so
+ * those runs finish on `legacyFlow` exactly as they would have pre-upgrade, and every new run
+ * takes `anchoredFlow`.
+ *
+ * REMOVAL. An ExecuteTransaction run lives seconds (3 broadcast attempts × 30s at worst), so no
+ * pre-upgrade history can still be open a few minutes after deploy. A later release should
+ * therefore delete `legacyFlow`, the `getTxTimeoutHeight` activity it is the last caller of, and
+ * this marker — the standard sequence being `deprecatePatch()` first if you want to be strict.
+ */
+const PATCH_COMMAND_SEQUENCE_V2 = 'execute-transaction-command-sequence-v2'
+
+/**
+ * Broadcaster. Anchors a pending transaction (hash + heights), broadcasts it, and leaves it
+ * `pending` for the VerifyPendingTransactions sweeper to settle against the chain. No
+ * verification happens here — that responsibility moved to the verifier so a slow or unreachable
+ * RPC can never turn a broadcast into a false failure on this path.
  */
 export async function ExecuteTransaction(args: TransactionArgs) {
   const { transactionId } = args;
 
-  const {
-    getTransaction,
-    updateTransaction,
-    executeTransaction,
-    getBlockHeight,
-    getTxTimeoutHeight,
-    notifyProviderOfFailedStakes,
-    notifyUserOfFailedTransaction,
-  } = proxyActivities<ReturnType<typeof delegatorActivities>>({
+  const activities = proxyActivities<Activities>({
     startToCloseTimeout: "30s",
     retry: {
       maximumAttempts: 3,
     },
   });
 
-  const transaction = await getTransaction(transactionId);
+  const transaction = await activities.getTransaction(transactionId);
 
+  // Someone else already settled this row. Return, do NOT throw: a plain Error from workflow code
+  // does not fail the RUN — the SDK turns it into an unhandled rejection, which fails the workflow
+  // TASK, and the server retries that forever. The run then sits RUNNING permanently and the
+  // dispatcher cannot start a replacement (ALLOW_DUPLICATE_FAILED_ONLY needs a FAILED run), so the
+  // tx is stranded with no error surfaced anywhere — the wedge noWorkflowError.test.ts documents
+  // (that guard only greps for a constructed WorkflowError, so a plain Error slips past it).
+  // Anchoring before
+  // broadcast widened this: the verifier can settle a row while this workflow is still inside its
+  // ~90s broadcast phase, so a retried run routinely finds it terminal.
   if (transaction.status !== TransactionStatus.Pending) {
-    throw new Error("Transaction is not pending");
-  }
-
-  // Already broadcast (has a hash) → the verifier owns it; nothing to do here.
-  if (transaction.hash) {
-    log.debug('ExecuteTransaction: already broadcast, handing off to verifier', { transactionId, hash: transaction.hash });
+    log.info('ExecuteTransaction: transaction already settled, nothing to do', { transactionId, status: transaction.status });
     return { ...transaction };
   }
 
-  const txHeight = await getBlockHeight();
+  // A hash means the anchor was written, so the verifier owns this row from here on.
+  //
+  // Since the anchor is written BEFORE broadcasting, a hash no longer proves the bytes reached a
+  // node — only that we committed to sending them. A run that died between the anchor and a
+  // successful broadcast therefore returns here without re-sending, and the verifier settles it
+  // (Failure once coverage passes timeoutHeight, since the tx never landed). That is a correct
+  // verdict reached slowly; re-broadcasting instead would resolve it faster and is safe under the
+  // current classification (an in-mempool repeat answers code 19 → dedup-success, a landed one
+  // answers code 32 → indeterminate), but it is a behavioural change worth making deliberately
+  // rather than as a side effect of this fix.
+  if (transaction.hash) {
+    log.debug('ExecuteTransaction: anchored already, handing off to verifier', { transactionId, hash: transaction.hash });
+    return { ...transaction };
+  }
+
+  const txHeight = await activities.getBlockHeight();
+
+  // The gate sits here deliberately: everything above is byte-identical in both versions (same
+  // three commands, same order), so a pre-upgrade history replays cleanly up to this point.
+  // Everything below changed shape and must be inside the gate.
+  return patched(PATCH_COMMAND_SEQUENCE_V2)
+    ? anchoredFlow(activities, transaction, txHeight, transactionId)
+    : legacyFlow(activities, transaction, txHeight, transactionId);
+}
+
+/** Post-#339 flow. See the patch marker above for why the pre-#339 one is still in this file. */
+async function anchoredFlow(
+  activities: ProxiedActivities,
+  transaction: TransactionRow,
+  txHeight: number,
+  transactionId: number,
+) {
+  const {
+    updateTransaction,
+    executeTransaction,
+    persistBroadcastAnchor,
+    claimBroadcastFailure,
+    recordBroadcastDiagnostics,
+    notifyProviderOfFailedStakes,
+    notifyUserOfFailedTransaction,
+  } = activities;
 
   // No hash and the broadcast window already expired → mark failed immediately.
+  if (transaction.executionHeight && txHeight - transaction.executionHeight > TX_EXPIRATION_BLOCKS) {
+    log.warn('ExecuteTransaction: expired before broadcast', { transactionId });
+    // Effects BEFORE the status flip, per the invariant documented on claimTerminalTransition
+    // (lib/dal/transaction.ts): effects are idempotent and a partial run is re-swept, but a
+    // status flip first is unrecoverable — the re-entry guard above throws "Transaction is not
+    // pending", so a crash in between would strand the provider's addresses forever.
+    if (transaction.type === TransactionType.Stake) {
+      await notifyProviderOfFailedStakes(transaction.id);
+    }
+    await notifyUserOfFailedTransaction(transactionId, 'TX expired before broadcast');
+    await updateTransaction(transactionId, {
+      status: TransactionStatus.Failure,
+      log: 'TX expired before broadcast',
+    });
+    return { ...transaction, status: TransactionStatus.Failure };
+  }
+
+  // Anchor the tx BEFORE broadcasting: hash (derived locally from the signed bytes),
+  // executionHeight (sampled above, so it can never exceed the first possible inclusion height)
+  // and the embedded timeoutHeight. Once written, a crash anywhere below re-enters at the
+  // `transaction.hash` guard and hands the tx to the verifier instead of broadcasting twice.
+  const hash = await persistBroadcastAnchor(transactionId, txHeight);
+
+  // null = the signed payload cannot even be decoded, so it can never be broadcast or land.
+  // Deterministic, and terminal — the alternative is a row the dispatcher retries forever.
+  if (!hash) {
+    log.error('ExecuteTransaction: signed payload is not broadcastable', { transactionId });
+    if (transaction.type === TransactionType.Stake) {
+      await notifyProviderOfFailedStakes(transaction.id);
+    }
+    await notifyUserOfFailedTransaction(transactionId, 'Signed transaction payload is malformed');
+    await updateTransaction(transactionId, {
+      status: TransactionStatus.Failure,
+      log: 'signed payload is not valid hex — nothing could be broadcast',
+    });
+    return { ...transaction, status: TransactionStatus.Failure };
+  }
+
+  const result = await executeTransaction(transaction.id);
+
+  // NOTE ON `result.neverSent`: it is reported (and logged by the activity) but deliberately not
+  // acted on. Clearing the anchor to allow a re-broadcast would be destructive — it hides a tx
+  // that may be in a mempool from the verifier, which is #339 itself — and it is unnecessary:
+  // an unknown outcome keeps the anchor, so the verifier settles the row either way. The flag
+  // earns its place as a diagnostic that separates "we never reached the node" from "we reached
+  // it and heard nothing back".
+
+  // Only a deterministic CheckTx rejection ON THE FIRST ATTEMPT is proof of failure. A retry
+  // re-broadcasts identical bytes, and if the earlier attempt already landed the tx, the node
+  // answers about the world that tx created — insufficient funds now that the stake deducted the
+  // balance, or a consumed sequence. Those read as rejections but mean "already landed". Only the
+  // verifier can tell the difference, so a rejection on a retry is handed to it. See #339.
+  if (result.rejected && result.attempt === 1) {
+    log.warn('ExecuteTransaction: broadcast rejected by node', { transactionId, hash, code: result.code, message: result.message });
+    // CAS FIRST here — the opposite order to the expired branch above, deliberately.
+    //
+    // That branch runs effects first because its row has no hash, so no other writer can see it
+    // and the only risk is losing an effect. This row has been visible to the verifier since the
+    // anchor, and the verifier can reach the OPPOSITE verdict: decideVerification returns success
+    // on goal-state alone (a sibling tx staked the same operator), creates the node rows and tells
+    // the provider those addresses are staked. Releasing them afterwards is a destructive
+    // cross-app write contradicting the verdict that stands, and it is NOT recoverable: the
+    // provider's markStaked requires state=Delivered, so a release landing first turns the
+    // verifier's success effect into a silent no-op and the key can be re-delivered to another
+    // delegator. Nothing fires unless this call is the one that terminalized the row.
+    const claimed = await claimBroadcastFailure(transactionId, {
+      code: result.code,
+      log: result.message || 'broadcast rejected',
+    });
+    if (!claimed) {
+      log.info('ExecuteTransaction: verifier settled this row first, standing down', { transactionId });
+      return { ...transaction };
+    }
+
+    if (transaction.type === TransactionType.Stake) {
+      await notifyProviderOfFailedStakes(transaction.id);
+    }
+    await notifyUserOfFailedTransaction(transactionId, result.message || 'Broadcast rejected by the node');
+    return { ...transaction, status: TransactionStatus.Failure, code: result.code };
+  }
+
+  if (result.rejected) {
+    log.warn('ExecuteTransaction: rejection on a retry — deferring to the verifier', {
+      transactionId,
+      hash,
+      attempt: result.attempt,
+      code: result.code,
+      message: result.message,
+    });
+  }
+
+  if (result.success) {
+    log.info('ExecuteTransaction: broadcast succeeded', { transactionId, hash, executionHeight: txHeight });
+    return { ...transaction, hash, executionHeight: txHeight };
+  }
+
+  // Outcome unknown. The anchor is already persisted and the row is still `pending`, so it sits
+  // in listPendingWithHash's queue and the verifier settles it against the chain. Record the
+  // transport error for triage — without this the reason is lost, and a later verdict would
+  // read only the verifier's generic "validity bound covered" text.
+  log.warn('ExecuteTransaction: broadcast outcome unknown, handing to verifier', {
+    transactionId,
+    hash,
+    executionHeight: txHeight,
+    isTimeout: result.isTimeout,
+    code: result.code,
+    message: result.message,
+  });
+  await recordBroadcastDiagnostics(transactionId, {
+    code: result.code,
+    log: result.message || 'broadcast outcome unknown (awaiting verification)',
+  });
+
+  return { ...transaction, hash, executionHeight: txHeight };
+}
+
+/**
+ * Pre-#339 flow, kept VERBATIM so runs that were open across the upgrade replay to completion.
+ * Do not "improve" anything in here — every command and its order must match the histories those
+ * runs already recorded. Delete it (with `getTxTimeoutHeight`) once no pre-upgrade run can exist.
+ *
+ * Note these runs are not stuck with the old bug: activities are never version-pinned, so this
+ * path calls the fixed `sendTransaction`, which now always returns a locally derived hash. The
+ * `!result.transactionHash` branch below therefore no longer fires on a transport failure — the
+ * row gets its hash and the verifier settles it, which is the substance of the #339 fix.
+ */
+async function legacyFlow(
+  activities: ProxiedActivities,
+  transaction: TransactionRow,
+  txHeight: number,
+  transactionId: number,
+) {
+  const {
+    updateTransaction,
+    executeTransaction,
+    getTxTimeoutHeight,
+    notifyProviderOfFailedStakes,
+    notifyUserOfFailedTransaction,
+  } = activities;
+
   if (transaction.executionHeight && txHeight - transaction.executionHeight > TX_EXPIRATION_BLOCKS) {
     log.warn('ExecuteTransaction: expired before broadcast', { transactionId });
     await updateTransaction(transactionId, {
@@ -80,15 +295,10 @@ export async function ExecuteTransaction(args: TransactionArgs) {
     return { ...transaction, status: TransactionStatus.Failure, code: result.code };
   }
 
-  // Broadcast succeeded: parse timeoutHeight from the signed payload (embedded at signing
-  // by KeplrWalletConnection; null for external-wallet txs that omit it).
   const timeoutHeight = await getTxTimeoutHeight(transactionId);
 
   log.info('ExecuteTransaction: broadcast succeeded', { transactionId, hash: result.transactionHash, executionHeight: txHeight });
 
-  // Persist hash + height + timeoutHeight and hand off to the verifier.
-  // executionHeight was sampled BEFORE broadcast (line ~47) — this must not move after
-  // broadcast or the anchor would be ≥ the first possible inclusion height.
   await updateTransaction(transactionId, {
     executionHeight: txHeight,
     hash: result.transactionHash,

--- a/packages/pocket/src/index.ts
+++ b/packages/pocket/src/index.ts
@@ -117,6 +117,36 @@ const UNORDERED_TIMEOUT_MS = 9 * 60 * 1000
  * errorsmod.Wrapf message from the unordered handler). This is a best-effort match;
  * if pocket-network's fork uses a different code, update the code number here.
  */
+/**
+ * The transaction hash for a signed payload, derived without asking the chain: sha256 of the
+ * exact bytes broadcast, uppercase hex. Identical to what CometBFT returns from
+ * `broadcast_tx_sync` and to the derivation `matchTxInBlock` uses when scanning a block, so a
+ * hash produced here is findable on-chain later.
+ *
+ * @param signedPayloadHex hex-encoded signed TxRaw bytes (middleman's storage encoding)
+ * @throws if the payload is not valid hex — `Buffer.from(x, 'hex')` truncates silently at the
+ *   first invalid character, and an empty result would yield sha256('') for every bad payload,
+ *   writing one constant hash across unrelated transactions.
+ */
+export function deriveTxHash(signedPayloadHex: string): string {
+  if (!/^[0-9a-fA-F]*$/.test(signedPayloadHex) || signedPayloadHex.length === 0 || signedPayloadHex.length % 2 !== 0) {
+    throw new Error('deriveTxHash: signed payload is not valid hex')
+  }
+  return toHex(sha256(Uint8Array.from(Buffer.from(signedPayloadHex, 'hex')))).toUpperCase()
+}
+
+/**
+ * CheckTx codes that do NOT prove the transaction can never land, even though cosmjs raises the
+ * same BroadcastTxError for them as for a real rejection:
+ *   32 (ErrWrongSequence)  — the sequence is already consumed (the tx ALREADY LANDED) or a
+ *                            predecessor is still in the mempool (this tx lands after it).
+ *   20 (ErrMempoolIsFull)  — the node had no room; the bytes are still valid and may be accepted
+ *                            on a later attempt or by another node.
+ * Treating either as terminal is how a landed transaction gets recorded as failed — the exact
+ * defect #339 is about. Route them to the verifier instead and let the chain answer.
+ */
+const INDETERMINATE_CHECKTX_CODES = new Set([20, 32])
+
 function isUnorderedDedupRejection(e: unknown): boolean {
   if (!(e instanceof Error)) return false
   const err = e as Error & { code?: number; codespace?: string; rawLog?: string }
@@ -329,22 +359,106 @@ export class PocketBlockchain {
 
   /**
    * Broadcasts a signed transaction (hex-encoded) to the network.
+   *
+   * The returned hash is derived LOCALLY (sha256 of the exact bytes broadcast, the same
+   * derivation `matchTxInBlock` uses during a block scan), so the caller holds it even when
+   * the node's reply never arrives. That matters because a transport failure is not evidence
+   * of anything: the node may have accepted the tx into its mempool before the socket died,
+   * in which case it still lands on-chain. Only `rejected` says the tx can never land.
+   *
+   * Mirrors `broadcastSupplierTx`'s ladder, on `broadcastTxSync` (which THROWS
+   * BroadcastTxError on a non-zero CheckTx code) instead of `broadcastTx`.
+   *
    * @param payload hex string of the signed tx bytes
-   * @returns transactionHash and the full BroadcastTxResponse
+   * @returns transactionHash (locally derived) plus the outcome discriminator `rejected`
    */
   async sendTransaction(payload: string): Promise<SendTransactionResult> {
-    const client = await this.getStargateClient()
-    const txBytes = Buffer.from(payload, 'hex')
+    const localHash = deriveTxHash(payload)
+    const txBytes = Uint8Array.from(Buffer.from(payload, 'hex'))
+
+    // Connection setup is its own failure class: if we cannot reach the node at all, nothing was
+    // transmitted. Reporting that as `neverSent` lets the caller roll back a pre-broadcast anchor
+    // and try again later, instead of stranding a tx that was never actually sent. Everything
+    // after this point may have reached the node, so none of it is safely retryable.
+    let client: StargateClient
+    try {
+      client = await this.getStargateClient()
+    } catch (error) {
+      const err = error as { message?: string }
+      this.logger.error('sendTransaction: RPC unreachable, nothing was broadcast', { message: err.message })
+      return {
+        transactionHash: localHash,
+        success: false,
+        rejected: false,
+        neverSent: true,
+        message: err.message ?? 'RPC unreachable — nothing was broadcast',
+      }
+    }
+
     try {
       const transactionHash = await client.broadcastTxSync(txBytes)
-      return { transactionHash, success: true }
+      return { transactionHash, success: true, rejected: false }
     } catch (error) {
+      // Cosmos SDK unordered dedup: re-broadcasting identical bytes is refused because the tx
+      // is already tracked in the unordered nonce cache. That means it IS (or will be) on-chain.
+      if (isUnorderedDedupRejection(error)) {
+        this.logger.info('sendTransaction: unordered dedup (already broadcast), treating as success', { transactionHash: localHash })
+        return {
+          transactionHash: localHash,
+          code: 0,
+          message: 'already broadcast (unordered dedup)',
+          success: true,
+          rejected: false,
+        }
+      }
 
-      const err = error as { code?: number; message?: string; log?: string }
+      // CheckTx answered with a non-zero code. Deterministic ones are proof the tx can never
+      // land; the codes in INDETERMINATE_CHECKTX_CODES are not (see that constant) and must go
+      // to the verifier instead of being written off as failures.
+      if (error instanceof BroadcastTxError) {
+        // Codespace-scoped: cosmos error codes are namespaced, so code 20/32 only carry the
+        // meanings below in the SDK root codespace. A module error that happens to reuse those
+        // numbers must NOT inherit the indeterminate treatment.
+        const indeterminate = error.codespace === 'sdk' && INDETERMINATE_CHECKTX_CODES.has(error.code)
+        const level = indeterminate ? 'warn' : 'error'
+        this.logger[level](
+          indeterminate
+            ? 'sendTransaction: CheckTx code is indeterminate (tx may still land, not rejected)'
+            : 'sendTransaction: hard CheckTx rejection',
+          { code: error.code, codespace: error.codespace, message: error.message },
+        )
+        return {
+          transactionHash: localHash,
+          success: false,
+          rejected: !indeterminate,
+          code: error.code,
+          codespace: error.codespace,
+          // `.log` is the clean ABCI error; `.message` is the verbose cosmjs wrapper.
+          message: error.log ?? error.message ?? 'broadcast rejected',
+        }
+      }
+
+      // Timeout: the node never answered, but may well have accepted the tx. Outcome UNKNOWN.
+      if (error instanceof TimeoutError) {
+        this.logger.warn('sendTransaction: RPC timeout (tx may still land, not rejected)', { transactionHash: localHash, message: error.message })
+        return {
+          transactionHash: localHash,
+          success: false,
+          rejected: false,
+          isTimeout: true,
+          message: `RPC timeout waiting for broadcast confirmation — tx may still land: ${error.message}`,
+        }
+      }
+
+      // Anything else (socket reset, proxy 5xx, DNS): same unknown-outcome class as a timeout.
+      const err = error as { code?: number; codespace?: string; message?: string; log?: string }
+      this.logger.error('sendTransaction: broadcast failed (outcome unknown, not rejected)', { code: err.code, codespace: err.codespace, message: err.message })
       return {
-        transactionHash: '',
+        transactionHash: localHash,
         success: false,
-        code: err.code,
+        rejected: false,
+        code: typeof err.code === 'number' ? err.code : undefined,
+        codespace: err.codespace,
         message: err.log ?? err.message,
       }
     }

--- a/packages/pocket/src/sendTransaction.test.ts
+++ b/packages/pocket/src/sendTransaction.test.ts
@@ -1,0 +1,269 @@
+// ---------------------------------------------------------------------------
+// Mocks – must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockBroadcastTxSync = jest.fn()
+const mockGetHeight = jest.fn()
+const mockDisconnect = jest.fn()
+const mockStatus = jest.fn()
+
+jest.mock('@cosmjs/stargate', () => {
+  const actual = jest.requireActual('@cosmjs/stargate')
+  return {
+    ...actual,
+    StargateClient: {
+      create: jest.fn().mockResolvedValue({
+        broadcastTxSync: mockBroadcastTxSync,
+        getHeight: mockGetHeight,
+        disconnect: mockDisconnect,
+      }),
+    },
+  }
+})
+
+jest.mock('@cosmjs/tendermint-rpc', () => ({
+  connectComet: jest.fn().mockResolvedValue({
+    status: mockStatus,
+    disconnect: mockDisconnect,
+  }),
+}))
+
+jest.mock('@igniter/logger', () => {
+  const mk = () => {
+    const l: Record<string, unknown> = {
+      info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), trace: jest.fn(),
+      with: () => l, getChild: () => l,
+    }
+    return l
+  }
+  return { getLogger: () => mk() }
+})
+
+import { PocketBlockchain } from './index'
+import { BroadcastTxError, TimeoutError } from '@cosmjs/stargate'
+import { sha256 } from '@cosmjs/crypto'
+import { toHex } from '@cosmjs/encoding'
+import { createHash } from 'node:crypto'
+
+// Any hex blob works: sendTransaction broadcasts the bytes without decoding them.
+const SIGNED_PAYLOAD = 'deadbeef'.repeat(8)
+const EXPECTED_LOCAL_HASH = toHex(sha256(Uint8Array.from(Buffer.from(SIGNED_PAYLOAD, 'hex')))).toUpperCase()
+
+async function createInstance() {
+  return PocketBlockchain.setup('http://localhost:26657', 'upokt', 0.001)
+}
+
+/**
+ * #339: a broadcast error is not evidence the tx failed. Only a hard CheckTx rejection proves
+ * the tx can never land; every other error leaves the outcome unknown, and the caller needs a
+ * hash to hand the tx to the verifier. These tests pin that discrimination.
+ */
+describe('PocketBlockchain.sendTransaction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('success: returns the node-reported hash and rejected=false', async () => {
+    const nodeHash = 'ABCD1234'.repeat(8)
+    mockBroadcastTxSync.mockResolvedValue(nodeHash)
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    expect(result.success).toBe(true)
+    expect(result.rejected).toBe(false)
+    expect(result.transactionHash).toBe(nodeHash)
+  })
+
+  it('BroadcastTxError: rejected=true (hard CheckTx rejection — tx can never land)', async () => {
+    mockBroadcastTxSync.mockRejectedValue(new BroadcastTxError(11, 'sdk', 'out of gas in ante handler'))
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    expect(result.success).toBe(false)
+    expect(result.rejected).toBe(true)
+    expect(result.code).toBe(11)
+    expect(result.codespace).toBe('sdk')
+    expect(result.message).toContain('out of gas')
+  })
+
+  it('code 32 (wrong sequence): NOT rejected — the tx may already have landed', async () => {
+    // CheckTx answers 32 both when the sequence is already consumed (the tx landed) and when a
+    // predecessor is still in the mempool (this one lands next). Writing Failure here would
+    // recreate #339 inside its own fix, and would release the provider's addresses.
+    mockBroadcastTxSync.mockRejectedValue(new BroadcastTxError(32, 'sdk', 'account sequence mismatch'))
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    expect(result.success).toBe(false)
+    expect(result.rejected).toBe(false)
+    expect(result.code).toBe(32)
+    expect(result.transactionHash).toBe(EXPECTED_LOCAL_HASH)
+  })
+
+  it('code 20 (mempool full): NOT rejected — the bytes are still valid', async () => {
+    mockBroadcastTxSync.mockRejectedValue(new BroadcastTxError(20, 'sdk', 'mempool is full'))
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    expect(result.rejected).toBe(false)
+    expect(result.code).toBe(20)
+  })
+
+  it('rejects a payload that is not valid hex instead of hashing empty bytes', async () => {
+    const bc = await createInstance()
+
+    // Buffer.from(x,'hex') truncates at the first invalid char; an empty result would write
+    // sha256('') as the hash of every malformed tx.
+    await expect(bc.sendTransaction('nothex!!')).rejects.toThrow(/not valid hex/)
+    expect(mockBroadcastTxSync).not.toHaveBeenCalled()
+  })
+
+  it('TimeoutError: rejected=false and the locally derived hash is returned', async () => {
+    mockBroadcastTxSync.mockRejectedValue(new TimeoutError('timeout waiting for commit', 'DEADBEEF'.repeat(8)))
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    expect(result.success).toBe(false)
+    expect(result.rejected).toBe(false)
+    expect(result.isTimeout).toBe(true)
+    expect(result.transactionHash).toBe(EXPECTED_LOCAL_HASH)
+  })
+
+  it('transport failure (socket reset): rejected=false and the hash still comes back', async () => {
+    mockBroadcastTxSync.mockRejectedValue(Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }))
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    expect(result.success).toBe(false)
+    expect(result.rejected).toBe(false)
+    expect(result.transactionHash).toBe(EXPECTED_LOCAL_HASH)
+    // A string errno must never masquerade as a chain error code.
+    expect(result.code).toBeUndefined()
+  })
+
+  it('unordered dedup: an "already in mempool" rejection is success, not failure', async () => {
+    mockBroadcastTxSync.mockRejectedValue(
+      Object.assign(new Error('tx already exists in cache'), { code: 19, codespace: 'sdk' }),
+    )
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    expect(result.success).toBe(true)
+    expect(result.rejected).toBe(false)
+    expect(result.transactionHash).toBe(EXPECTED_LOCAL_HASH)
+    expect(result.message).toBe('already broadcast (unordered dedup)')
+  })
+
+  it('code 32 in a NON-sdk codespace is still a hard rejection', async () => {
+    // Cosmos error codes are codespace-scoped: a module error reusing the number 32 has nothing
+    // to do with ErrWrongSequence and must not inherit the indeterminate treatment.
+    mockBroadcastTxSync.mockRejectedValue(new BroadcastTxError(32, 'supplier', 'module-specific failure'))
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    expect(result.rejected).toBe(true)
+  })
+
+  it('RPC unreachable: neverSent=true so the caller can safely retry', async () => {
+    const bc = await createInstance()
+    // Connection setup fails — no bytes are transmitted, which is the one error class that is
+    // provably safe to retry (and to roll a pre-broadcast anchor back for).
+    jest.spyOn(bc as unknown as { getStargateClient: () => Promise<unknown> }, 'getStargateClient')
+      .mockRejectedValue(new Error('Failed to connect to the blockchain.'))
+
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    expect(result.neverSent).toBe(true)
+    expect(result.rejected).toBe(false)
+    expect(result.success).toBe(false)
+    expect(mockBroadcastTxSync).not.toHaveBeenCalled()
+  })
+
+  it('a broadcast that DID happen is never marked neverSent', async () => {
+    mockBroadcastTxSync.mockRejectedValue(Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }))
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    // The bytes may have reached the node, so this must NOT look retry-safe.
+    expect(result.neverSent).toBeUndefined()
+  })
+
+  it('the derived hash matches an independently computed sha256 (not just our own expression)', async () => {
+    // Computed with node:crypto rather than @cosmjs/crypto, so this cannot pass by echoing the
+    // implementation's own derivation back at itself.
+    const independent = createHash('sha256')
+      .update(Buffer.from(SIGNED_PAYLOAD, 'hex'))
+      .digest('hex')
+      .toUpperCase()
+
+    mockBroadcastTxSync.mockRejectedValue(new Error('no answer'))
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    expect(result.transactionHash).toBe(independent)
+  })
+
+  it('hashes exactly the bytes it broadcasts', async () => {
+    // The invariant the anchor rests on. `deriveTxHash(payload)` and `Buffer.from(payload,'hex')`
+    // are two independent decodes of the same string: if they ever diverge, every anchored hash
+    // matches nothing on chain and the verifier drives every tx to Failure after the bound —
+    // #339 again, with a worse failure mode. Assert against the bytes actually handed to cosmjs.
+    mockBroadcastTxSync.mockRejectedValue(new Error('no answer'))
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    const broadcastBytes = mockBroadcastTxSync.mock.calls[0]![0] as Uint8Array
+    expect(toHex(sha256(broadcastBytes)).toUpperCase()).toBe(result.transactionHash)
+  })
+
+  it('rejects an odd-length payload (silent truncation would change the bytes)', async () => {
+    const bc = await createInstance()
+
+    await expect(bc.sendTransaction('deadbee')).rejects.toThrow(/not valid hex/)
+    expect(mockBroadcastTxSync).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty payload rather than hashing zero bytes', async () => {
+    const bc = await createInstance()
+
+    // sha256('') is a constant — without this guard it would be written as the hash of every
+    // malformed transaction, colliding unrelated rows on one anchor.
+    await expect(bc.sendTransaction('')).rejects.toThrow(/not valid hex/)
+    expect(mockBroadcastTxSync).not.toHaveBeenCalled()
+  })
+
+  it('the node-reported hash and the locally derived hash agree', async () => {
+    // The invariant the whole design rests on: what CometBFT returns from broadcast_tx_sync is
+    // sha256 of the same bytes we hashed, so an anchor written before broadcasting is the hash
+    // the chain will know the tx by.
+    mockBroadcastTxSync.mockResolvedValue(EXPECTED_LOCAL_HASH)
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    expect(result.transactionHash).toBe(EXPECTED_LOCAL_HASH)
+  })
+
+  it('the derived hash matches the block-scan derivation (sha256 of the broadcast bytes)', async () => {
+    mockBroadcastTxSync.mockRejectedValue(new Error('no answer'))
+
+    const bc = await createInstance()
+    const result = await bc.sendTransaction(SIGNED_PAYLOAD)
+
+    // Same derivation matchTxInBlock uses to match a tx while scanning a block, so a hash
+    // produced here is findable on-chain by the verifier.
+    expect(result.transactionHash).toMatch(/^[0-9A-F]{64}$/)
+    expect(result.transactionHash).toBe(EXPECTED_LOCAL_HASH)
+  })
+})

--- a/packages/pocket/src/types.ts
+++ b/packages/pocket/src/types.ts
@@ -62,6 +62,13 @@ export interface SendTransactionResult {
    * where the tx may still land. Callers must treat undefined as non-rejected.
    */
   rejected?: boolean;
+  /**
+   * True only when we can PROVE no bytes were transmitted — the RPC connection could not be
+   * established, so the broadcast never happened. Distinct from a timeout or a reset, where the
+   * node may have received and accepted the tx. Callers may safely retry (or roll back a
+   * pre-broadcast anchor) on this and only this signal.
+   */
+  neverSent?: boolean;
   /** Chain head sampled immediately before signing — the lowest possible inclusion height anchor. */
   signedAtHeight?: number;
   /** timeoutHeight embedded in the signed tx; inclusion in any block > this height is impossible. */


### PR DESCRIPTION
A broadcast with no clean answer was written `Failure` with no hash: invisible to the verifier forever, though the tx may have landed.

`sendTransaction` now derives the hash locally (sha256 of the bytes it broadcasts, as `matchTxInBlock` does), so every outcome carries one.

It also stops flattening errors: dedup is success, a deterministic CheckTx rejection is `rejected`, timeouts and resets are unknown.

`ExecuteTransaction` anchors hash + heights BEFORE broadcasting; an unknown outcome stays `pending` for the chain to settle.